### PR TITLE
ci: use stable workflow foundation

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-major-version.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-minor-version.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: kungfu-trader/workflows/.github/workflows/.release-new-version.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2
     with:
       publish-aws-ci: false
       publish-aws-user: false

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   try:
-    uses: kungfu-trader/workflows/.github/workflows/.release-verify.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2
     with:
       prebuild: false
       find-dependencies: false
@@ -19,7 +19,7 @@ jobs:
   
   verify:
     needs: try
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: report
         run: echo verified

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: "team name"
     required: false
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@kungfu-trader/action-set-collaborators",
   "version": "1.0.2-alpha.0",
   "main": "dist/index.js",
-  "repository": "https://github.com/kungfu-trader/action-set-collaborators",
+  "repository": "https://github.com/kungfu-systems/action-set-collaborators",
   "author": "Kungfu Trader",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- migrate workflow callers from kungfu-trader/workflows v1 to stable kungfu-systems/workflows v2
- update the verify runner from ubuntu-20.04 to ubuntu-24.04
- update the action runtime from node20 to node24
- update package repository metadata to kungfu-systems

## Validation
- actionlint -color=false on all workflow files
- residual scan for old owner, alpha foundation refs, and deprecated runtime markers
- git diff --check

Yarn build was not rerun because this change does not modify source or dist files and this local checkout does not have project dependencies installed.