### PR TITLE
ci: remove legacy Airtable verify secret

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -14,7 +14,6 @@ jobs:
       prebuild: false
       find-dependencies: false
     secrets:
-      AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
       NODE_AUTH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
   
   verify:


### PR DESCRIPTION
## Summary\n- remove AIRTABLE_API_KEY from workflows@v2 release verify call\n- fixes startup_failure caused by passing undeclared reusable workflow secrets\n\n## Verification\n- actionlint .github/workflows/release-verify.yml\n- git diff --check