### PR TITLE
Prerelease v1 remove legacy Airtable verify secret

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -14,7 +14,6 @@ jobs:
       prebuild: false
       find-dependencies: false
     secrets:
-      AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
       NODE_AUTH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
   
   verify:


### PR DESCRIPTION
## Summary\n- publish removal of legacy AIRTABLE_API_KEY secret from workflows@v2 verify call\n- keeps Node24 runtime and stable workflows@v2 refs on alpha\n\n## Verification\n- PR #20 actionlint/git diff --check\n- release verify workflow